### PR TITLE
Use shutdown hook to write the remaining events

### DIFF
--- a/src/test/java/com/j256/cloudwatchlogbackappender/CloudWatchAppenderTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/CloudWatchAppenderTest.java
@@ -97,7 +97,7 @@ public class CloudWatchAppenderTest {
 				assertEquals(logGroup, request.getLogGroupName());
 				assertEquals(logStream, request.getLogStreamName());
 				List<InputLogEvent> events = request.getLogEvents();
-				assertEquals(1, events.size());
+				assertEquals(2, events.size());
 				assertEquals(fullMessage, events.get(0).getMessage());
 				return result;
 			}
@@ -453,7 +453,7 @@ public class CloudWatchAppenderTest {
 				assertEquals(logGroup, request.getLogGroupName());
 				assertEquals(logStream, request.getLogStreamName());
 				List<InputLogEvent> events = request.getLogEvents();
-				assertEquals(1, events.size());
+				assertEquals(2, events.size());
 				assertEquals(fullMessage, events.get(0).getMessage());
 				return putLogEventsResult;
 			}
@@ -529,7 +529,7 @@ public class CloudWatchAppenderTest {
 				assertEquals(logGroup, request.getLogGroupName());
 				assertEquals(logStream, request.getLogStreamName());
 				List<InputLogEvent> events = request.getLogEvents();
-				assertEquals(1, events.size());
+				assertEquals(2, events.size());
 				assertEquals(fullMessage, events.get(0).getMessage());
 				return putLogEventsResult;
 			}


### PR DESCRIPTION
Use shutdown hook to write the remaining events to CloudWatch when JVM shuts down.