### PR TITLE
Check if EC2 Metadata service lookup is enabled

### DIFF
--- a/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
+++ b/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
@@ -716,6 +716,9 @@ public class CloudWatchAppender extends UnsynchronizedAppenderBase<ILoggingEvent
 		}
 
 		private void lookupInstanceName(AWSCredentialsProvider credentialProvider) {
+			if (SDKGlobalConfiguration.isEc2MetadataDisabled()) {
+				return;
+			}
 			String instanceId = EC2MetadataUtils.getInstanceId();
 			if (instanceId == null) {
 				return;


### PR DESCRIPTION
AWS SDK allows to disable EC2 Metadata service lookup.

When it's disabled, we will see such exception stacktrace in the logs:
```
com.amazonaws.AmazonClientException: EC2 Instance Metadata Service is disabled
	at com.amazonaws.internal.InstanceMetadataServiceResourceFetcher.readResource(InstanceMetadataServiceResourceFetcher.java:65)
	at com.amazonaws.internal.EC2ResourceFetcher.readResource(EC2ResourceFetcher.java:66)
	at com.amazonaws.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:407)
	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:376)
	at com.amazonaws.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:372)
	at com.amazonaws.util.EC2MetadataUtils.fetchData(EC2MetadataUtils.java:426)
	at com.amazonaws.util.EC2MetadataUtils.fetchData(EC2MetadataUtils.java:420)
	at com.amazonaws.util.EC2MetadataUtils.getInstanceId(EC2MetadataUtils.java:140)
	at com.j256.cloudwatchlogbackappender.CloudWatchAppender$CloudWatchWriter.lookupInstanceName(CloudWatchAppender.java:729)
	at com.j256.cloudwatchlogbackappender.CloudWatchAppender$CloudWatchWriter.createLogsClient(CloudWatchAppender.java:639)
	at com.j256.cloudwatchlogbackappender.CloudWatchAppender$CloudWatchWriter.writeEvents(CloudWatchAppender.java:551)
	at com.j256.cloudwatchlogbackappender.CloudWatchAppender$CloudWatchWriter.run(CloudWatchAppender.java:537)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

We can add a simple check inside our Appender to verify this case and avoid useless error in logs.