### PR TITLE
upgrade to logback 1.3.5 (slf4j 2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<properties>
 		<disableDoclint />
 		<!-- optional dependencies -->
-		<logback.version>1.2.10</logback.version>
+		<logback.version>1.3.5</logback.version>
 		<aws-version>1.11.914</aws-version>
 		<!-- test dependencies -->
 		<junit-version>4.13.2</junit-version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<properties>
 		<disableDoclint />
 		<!-- optional dependencies -->
-		<logback.version>1.4.5</logback.version>
+		<logback.version>1.2.10</logback.version>
 		<aws-version>1.11.914</aws-version>
 		<!-- test dependencies -->
 		<junit-version>4.13.2</junit-version>

--- a/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
+++ b/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
@@ -51,7 +51,6 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.spi.AppenderAttachable;
-import org.slf4j.Marker;
 
 /**
  * CloudWatch log appender for logback.
@@ -415,9 +414,7 @@ public class CloudWatchAppender extends UnsynchronizedAppenderBase<ILoggingEvent
 		newEvent.setLevel(loggingEvent.getLevel());
 		newEvent.setLoggerContextRemoteView(loggingEvent.getLoggerContextVO());
 		newEvent.setLoggerName(loggingEvent.getLoggerName());
-		for (Marker marker : loggingEvent.getMarkerList()) {
-			newEvent.addMarker(marker);
-		}
+		newEvent.setMarker(loggingEvent.getMarker());
 		newEvent.setMDCPropertyMap(loggingEvent.getMDCPropertyMap());
 		if (message == null) {
 			newEvent.setMessage(loggingEvent.getMessage());

--- a/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
+++ b/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
@@ -51,6 +51,7 @@ import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.spi.AppenderAttachable;
+import org.slf4j.Marker;
 
 /**
  * CloudWatch log appender for logback.
@@ -414,7 +415,11 @@ public class CloudWatchAppender extends UnsynchronizedAppenderBase<ILoggingEvent
 		newEvent.setLevel(loggingEvent.getLevel());
 		newEvent.setLoggerContextRemoteView(loggingEvent.getLoggerContextVO());
 		newEvent.setLoggerName(loggingEvent.getLoggerName());
-		newEvent.setMarker(loggingEvent.getMarker());
+		if (loggingEvent.getMarkerList() != null) {
+			for (Marker marker : loggingEvent.getMarkerList()) {
+				newEvent.addMarker(marker);
+			}
+		}
 		newEvent.setMDCPropertyMap(loggingEvent.getMDCPropertyMap());
 		if (message == null) {
 			newEvent.setMessage(loggingEvent.getMessage());


### PR DESCRIPTION
Since my previous PR #51 has been merged but logback version 1.4.5 is for Java 11, now I submit another PR using logback version 1.3.5 which is for Java 8.
This will fix the issue https://github.com/j256/cloudwatch-logback-appender/issues/50