### PR TITLE
Enable MDC values in CloudWatch logback appender

### DIFF
--- a/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
+++ b/src/main/java/com/j256/cloudwatchlogbackappender/CloudWatchAppender.java
@@ -2,11 +2,7 @@ package com.j256.cloudwatchlogbackappender;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -423,7 +419,13 @@ public class CloudWatchAppender extends UnsynchronizedAppenderBase<ILoggingEvent
 				newEvent.addMarker(marker);
 			}
 		}
-		// newEvent.setMDCPropertyMap(loggingEvent.getMDCPropertyMap());
+
+		Map<String, String> mdcMap = loggingEvent.getMDCPropertyMap();
+		newEvent.setMDCPropertyMap(
+			mdcMap != null ?
+				new HashMap<>(mdcMap) : Collections.emptyMap()
+		);
+
 		if (message == null) {
 			newEvent.setMessage(loggingEvent.getMessage());
 		} else {

--- a/src/test/java/com/j256/cloudwatchlogbackappender/CloudWatchAppenderTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/CloudWatchAppenderTest.java
@@ -638,6 +638,7 @@ public class CloudWatchAppenderTest {
 		event.setLoggerName(name);
 		event.setLevel(level);
 		event.setMessage(message);
+		event.setMDCPropertyMap(Collections.emptyMap());
 		if (time != null) {
 			event.setTimeStamp(time);
 		}

--- a/src/test/java/com/j256/cloudwatchlogbackappender/HostAddressConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/HostAddressConverterTest.java
@@ -19,6 +19,8 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import java.util.Collections;
+
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
 
 public class HostAddressConverterTest extends BaseConverterTest {
@@ -47,6 +49,7 @@ public class HostAddressConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();

--- a/src/test/java/com/j256/cloudwatchlogbackappender/HostNameConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/HostNameConverterTest.java
@@ -19,6 +19,8 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import java.util.Collections;
+
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
 
 public class HostNameConverterTest extends BaseConverterTest {
@@ -47,6 +49,7 @@ public class HostNameConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();

--- a/src/test/java/com/j256/cloudwatchlogbackappender/InstanceIdConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/InstanceIdConverterTest.java
@@ -16,6 +16,8 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import java.util.Collections;
+
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
 
 public class InstanceIdConverterTest extends BaseConverterTest {
@@ -45,6 +47,7 @@ public class InstanceIdConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();

--- a/src/test/java/com/j256/cloudwatchlogbackappender/InstanceNameConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/InstanceNameConverterTest.java
@@ -18,6 +18,8 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import java.util.Collections;
+
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
 
 public class InstanceNameConverterTest extends BaseConverterTest {
@@ -47,6 +49,7 @@ public class InstanceNameConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result = PutLogEventsResponse.builder().nextSequenceToken(sequence).build();

--- a/src/test/java/com/j256/cloudwatchlogbackappender/SystemEnvironConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/SystemEnvironConverterTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.assertEquals;
 import org.easymock.IAnswer;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -45,6 +47,7 @@ public class SystemEnvironConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();
@@ -93,6 +96,7 @@ public class SystemEnvironConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();
@@ -139,6 +143,7 @@ public class SystemEnvironConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();

--- a/src/test/java/com/j256/cloudwatchlogbackappender/SystemPropertyConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/SystemPropertyConverterTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertNotNull;
 import org.easymock.IAnswer;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -47,6 +49,7 @@ public class SystemPropertyConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();
@@ -95,6 +98,7 @@ public class SystemPropertyConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();
@@ -143,6 +147,7 @@ public class SystemPropertyConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result =  PutLogEventsResponse.builder().nextSequenceToken(sequence).build();

--- a/src/test/java/com/j256/cloudwatchlogbackappender/UuidConverterTest.java
+++ b/src/test/java/com/j256/cloudwatchlogbackappender/UuidConverterTest.java
@@ -18,6 +18,8 @@ import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsRequest;
+import java.util.Collections;
+
 import software.amazon.awssdk.services.cloudwatchlogs.model.PutLogEventsResponse;
 
 public class UuidConverterTest extends BaseConverterTest {
@@ -47,6 +49,7 @@ public class UuidConverterTest extends BaseConverterTest {
 		event.setLoggerName("name");
 		event.setLevel(Level.DEBUG);
 		event.setMessage("message");
+		event.setMDCPropertyMap(Collections.emptyMap());
 
 		String sequence = "ewopjfewfj";
 		final PutLogEventsResponse result = PutLogEventsResponse.builder().nextSequenceToken(sequence).build();


### PR DESCRIPTION
First of all, thank you for maintaining this library.

I observed that using MDC values in the logback pattern prevents logs from being recorded in CloudWatch entirely.

The attached fix would address this issue, and I hope it is helpful.

## Overview

Updated `CloudWatchAppender` to properly include MDC values in log output.

Previously, when MDC values were used in the logback `<pattern>` config (e.g., `[%X{traceId}]`), `CloudWatchAppender` failed to record any logs to CloudWatch. The same configuration works correctly with `ConsoleAppender`.

## Root Cause

The `setMDCPropertyMap()` call inside the `copyEvent()` method was commented out.

`CloudWatchAppender` copies log events for asynchronous delivery on a separate thread. During this process, the MDC property map does not seem to be transferred, leaving the copied event without the necessary context to process the log pattern.

## Fix

Uncommented `setMDCPropertyMap()` in `copyEvent()` and updated it to copy the original event's MDC map into a new `HashMap` after a `null` check.

It falls back to `Collections.emptyMap()` when the source MDC map is `null`.

## Validation

Validated using LocalStack to simulate AWS CloudWatch Logs locally.

The validation was performed on the [/jaeykweon/cloudwatch-logback-appender/tree/validate/mdc](https://github.com/jaeykweon/cloudwatch-logback-appender/tree/validate/mdc), where you can also run the same test to verify the fix.

(a `docker-compose.yml` for LocalStack is provided in that branch).

After running `CloudWatchAppenderRealTest#mdcCase`, I confirmed that `AWS logs.PutLogEvents` entries appear in the Docker LocalStack container logs. 

(These entries do not appear with the original code.)
